### PR TITLE
Update datasheet workflow

### DIFF
--- a/.github/workflows/tt_datasheet.yaml
+++ b/.github/workflows/tt_datasheet.yaml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - projects/tt_um_*/**
 
+env:
+  DATASHEET_TEMPLATE_VERSION: "1.0.0"
+
 jobs:
   build_datasheet:
     runs-on: ubuntu-24.04
@@ -29,13 +32,33 @@ jobs:
           cache: 'pip'
       - run: pip install -r tt/requirements.txt -r tt-multiplexer/py/requirements.txt
 
-      - name: Pandoc deps
+      - name: Setup environment
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y pandoc texlive-xetex librsvg2-bin
+          sudo apt-get install -y pandoc
+          wget https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz
+          tar -xvf typst-x86_64-unknown-linux-musl.tar.xz
+          mv typst-x86_64-unknown-linux-musl/typst /usr/bin
+      
+      - name: Test typst
+        run: |
+          typst --version
+          if [ ! $? -eq 0 ]; then
+            echo "There was a problem running typst --version"
+            exit 1
+          fi
 
-      - name: Generate datasheet
-        run: python ./tt/configure.py --dump-markdown datasheet.md --dump-pdf datasheet.pdf
+      - name: Setup template
+        run: |
+          mkdir -p ~/.local/share/typst/packages/local/tt-datasheet
+          cd ~/.local/share/typst/packages/local/tt-datasheet
+          git clone -v --branch $DATASHEET_TEMPLATE_VERSION https://github.com/TinyTapeout/tt-datasheet-template $DATASHEET_TEMPLATE_VERSION
+
+      - name: Generate datasheet files
+        run: python ./tt/configure.py --build-datasheet --doc-content-config datasheet_config.json --template-version $DATASHEET_TEMPLATE_VERSION
+
+      - name: Create PDF
+        run: typst compile datasheet.typ datasheet.pdf --font-path ~/.local/share/typst/packages/local/tt-datasheet/$DATASHEET_TEMPLATE_VERSION/resources/fonts
 
       - name: Check file existence and content
         run: |

--- a/datasheet.typ
+++ b/datasheet.typ
@@ -1,0 +1,9 @@
+#import "@local/tt-datasheet:1.0.0" as tt
+
+#show: tt.datasheet.with(
+  shuttle: "Sky 25B",
+  repo-link: "https://github.com/tinytapeout/tinytapeout-sky-25b",
+  theme: "bold",
+  theme-override-colour: tt.colours.THEME_SKY_BLUE,
+  projects: include "datasheet_manifest.typ"
+)

--- a/datasheet_config.json
+++ b/datasheet_config.json
@@ -1,0 +1,7 @@
+{
+    "version": 1,
+    "disabled": [
+        "tt_um_FG_TOP_Dominik_Brandstetter"
+    ],
+    "artwork": []
+}


### PR DESCRIPTION
This PR updates the datasheet workflow to use the new typst template. It relies on https://github.com/TinyTapeout/tt-support-tools/pull/123 as the processing script needs to be updated to support it.

It also disables one project from being included in the docs due to some formatting issues, as listed in `datasheet_config.json`.