### PR TITLE
chore: update `tt-support-tools` for updated pinouts

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -129,11 +129,11 @@ jobs:
       - name: Copy final results
         run: python ./tt/configure.py --copy-final-results
 
-      - name: Create chipfoundry submission
-        run: python ./tt/configure.py --create-chipfoundry-submission
+      - name: Create foundry submission directory
+        run: python ./tt/configure.py --create-foundry-submission
 
       - name: Patch GL power pin assignments
-        run: sed -i 's/^ assign \(v[a-z0-9]*\) = \(v[a-z]*\);$/ assign \1 = \2; assign \2 = \1;/' chipfoundry/verilog/gl/openframe_project_wrapper.v
+        run: sed -i 's/^ assign \(v[a-z0-9]*\) = \(v[a-z]*\);$/ assign \1 = \2; assign \2 = \1;/' foundry_submission/verilog/gl/openframe_project_wrapper.v
 
       - name: upload GDS artifact
         if: success() || failure()
@@ -163,11 +163,11 @@ jobs:
           name: shuttle_index
           path: shuttle_index.json
 
-      - name: upload ChipFoundry submission directory
+      - name: upload foundry submission directory
         uses: actions/upload-artifact@v4
         with:
-          name: chipfoundry_submission
-          path: chipfoundry
+          name: foundry_submission
+          path: foundry_submission
 
       # Install iverilog (required for GL simulation)
       - name: install iverilog

--- a/.github/workflows/precheck.yaml
+++ b/.github/workflows/precheck.yaml
@@ -44,7 +44,7 @@ jobs:
           workflow: gds.yaml
           run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
-          name: chipfoundry_submission
+          name: foundry_submission
           path: tinytapeout-submission
 
       - name: Patch FEOL deck to disable MR_tunm.CON.1
@@ -137,7 +137,7 @@ jobs:
           workflow: gds.yaml
           run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
-          name: chipfoundry_submission
+          name: foundry_submission
           path: tinytapeout-submission
 
       - name: Create final .oas file

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ chipfoundry/README.md
 efabless/
 # IHP submission files:
 ihp/
-
+# Auto generated foundry submission folder:
+foundry_submission/
 # pip-compile
 *.egg-info

--- a/verilog/dv/mux/Makefile
+++ b/verilog/dv/mux/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 export USER_PROJECT_VERILOG := $(abspath ../../../verilog)
-export CHIPFOUNDRY_SUBMISSION = $(abspath ../../../chipfoundry/)
+export FOUNDRY_SUBMISSION = $(abspath ../../../foundry_submission/)
 export TT_GL_VERILOG := $(abspath ../../../tt-multiplexer/ol2/tt_top/verilog/)
 
 SIM                 ?= icarus

--- a/verilog/includes/includes.gl.mux_top
+++ b/verilog/includes/includes.gl.mux_top
@@ -1,4 +1,4 @@
--v $(CHIPFOUNDRY_SUBMISSION)/verilog/gl/openframe_project_wrapper.v
+-v $(FOUNDRY_SUBMISSION)/verilog/gl/openframe_project_wrapper.v
 -v $(TT_GL_VERILOG)/tt_ctrl.v
 -v $(TT_GL_VERILOG)/tt_mux.v
 -v $(TT_GL_VERILOG)/tt_um_chip_rom.v


### PR DESCRIPTION
Ref https://github.com/TinyTapeout/tt-support-tools/pull/148

There isn't a corresponding branch on `tt-support-tools` for this shuttle, so I've checked out the latest commit on the main branch of `tt-support-tools`. This enables the updated pinouts in the datasheet.

This update however breaks the `gds` workflow due to the missing `--create-chipfoundry-submission` -- happy to try to fix it if there's a reference for how to use the `--create-foundry-submission` flag.